### PR TITLE
Feature/alt metadata json repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,20 +105,43 @@ Badges may also use custom JSON paths, allowing for multiple files per project f
 
 An example of a repo with multiple badges may be found here: [BYOBTest](https://github.com/RubbaBoy/BYOBTest)
 
+### Private repos or alternative repos
+It is now possible to host the generated json file in an alternate public repo. Which would allow you to have an action that runs on a private repo to host the badge metadata in a public repo
+
+**The general steps are as follows:**
+* Login to GitHub and create a Personal Access Token. (Select repo scope) and copy generated secret
+* Go to the private repo where the action runs. Settings > Secrets > New repository secret
+* Name your secret according to how you want to reference it within the BYOB workflow step. i.e `${{ ACTIONS_TOKEN }}` so you can reference them like `${{ secrets.ACTIONS_TOKEN }}`
+* Define the two optional inputs `repository` and `actor` where repository is in the form `nameOrg/repoName` and the actor is the user who created the personal access token. 
+* Finally, follow the steps above to obtain your URL but replace the `orgName/repo` part with your public repo
+
+#### Example
+
+```yaml
+NAME: github
+LABEL: 'GitHub'
+ICON: 'github'
+STATUS: 'BYOBTest'
+COLOR: blue
+GITHUB_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
+REPOSITORY: RubbaBoy/BYOBTest
+ACTOR: RubbaBoy
+```
+
 ### Inputs
 
-All inputs are required except for the last one displayed below.
-
-| **Name**     | **Default**     | **Description**                                              |
-| ------------ | --------------- | ------------------------------------------------------------ |
-| name         |                 | The alphanumeric (-_ included) name of the badge, 32 chars or less. Used only for identification purposes. |
-| label        |                 | The left label of the badge, usually static.                 |
-| icon         |                 | An icon name from [badgen](https://badgen.net/), or an SVG URL |
-| status       |                 | The right status as the badge, usually based on results.     |
-| color        |                 | The hex color of the badge.                                  |
-| github_token |                 | The GitHub token to push to the current repo. Suggested as `${{ secrets.GITHUB_TOKEN }}` |
-| path         | `/shields.json` | The absolute file path to store the JSON data to.            |
-| branch       | `shields`       | The branch to contain the shields file.                      |
+| **Name**     | **Required** | **Default**     | **Description**                                              |
+| ------------ | ----- | --------------- | ------------------------------------------------------------ |
+| name         | yes |                 | The alphanumeric (-_ included) name of the badge, 32 chars or less. Used only for identification purposes. |
+| label        | yes |                 | The left label of the badge, usually static.                 |
+| icon         | yes |                 | An icon name from [badgen](https://badgen.net/), or an SVG URL |
+| status       | yes |                 | The right status as the badge, usually based on results.     |
+| color        | yes |                 | The hex color of the badge.                                  |
+| github_token | yes |                 | The GitHub token to push to the current repo. Suggested as `${{ secrets.GITHUB_TOKEN }}` |
+| path         | no  | `/shields.json` | The absolute file path to store the JSON data to.            |
+| branch       | no  | `shields`       | The branch to contain the shields file.                      |
+| repository   | no  |                 | Allows to publish json to an alternate repo. Useful to host the json in a public repo and have the action in a private repo.                      |
+| actor        | no  |                 | Required if repository is specified to use along with custom GitHub Access token                      |
 
 ## How It Works
 
@@ -127,4 +150,3 @@ BYOB is very simple, consisting of the GitHub Action and a small server-side scr
 When the Action is invoked, it will update only the badge names that have changed, to allow for more persistent data. Whenever a badge is invoked, a push is made to the repo updating the file. No badge data is stored server-side.
 
 The actual badges hosted by [Badgen](https://badgen.net/) (A great service, check it out if you have a chance!). The hosted endpoint uses the code [here](https://github.com/RubbaBoy/BYOB/blob/master/index.js). It reads the given repositories' JSON file containing shields data in it, and returns a Badgen-generated badge. This uses the static Badgen `/badge`  endpoint to allow for much less caching, as paired with GitHub's aggressive caching it can be extremely slow.
-

--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,10 @@ inputs:
     description: 'The branch to contain the shields file.'
     required: false
     default: 'shields'
+  repository:
+    description: 'The user/repo or org/repo where shields.json will get pushed to, as long as action has access'
+    required: false
+    default: ''
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -46,3 +50,4 @@ runs:
     - ${{ inputs.path }}
     - ${{ inputs.github_token }}
     - ${{ inputs.branch }}
+    - ${{ inputs.repository }}

--- a/action.yml
+++ b/action.yml
@@ -39,7 +39,7 @@ inputs:
     required: false
     default: ''
   actor:
-    description: 'The account owner of a custom GitHub Access Token. Required if repository and custom token'
+    description: 'The account owner of a custom GitHub Access Token. Required if using a custom repository and custom token'
     required: false
     default: ''
 

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,11 @@ inputs:
     description: 'The user/repo or org/repo where shields.json will get pushed to, as long as action has access'
     required: false
     default: ''
+  actor:
+    description: 'The account owner of a custom GitHub Access Token. Required if repository and custom token'
+    required: false
+    default: ''
+
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -51,3 +56,4 @@ runs:
     - ${{ inputs.github_token }}
     - ${{ inputs.branch }}
     - ${{ inputs.repository }}
+    - ${{ inputs.actor }}

--- a/bin/main.dart
+++ b/bin/main.dart
@@ -15,6 +15,7 @@ void main(List<String> args) {
   final token = args[6];
   final branch = args[7];
   var repository = args[8];
+  var actor = args[9];
 
   if (!path.startsWith('/')) {
     path = '/$path';
@@ -23,8 +24,12 @@ void main(List<String> args) {
     repository = env['GITHUB_REPOSITORY'].toString();
   }
 
+  if (actor.isEmpty) {
+    actor = env['GITHUB_ACTOR'].toString();
+  }
+
   final remote =
-      'https://${env['GITHUB_ACTOR']}:$token@github.com/$repository.git';
+      'https://$actor:$token@github.com/$repository.git';
 
   final cloneInto = 'repo-${DateTime.now().millisecondsSinceEpoch}';
 

--- a/bin/main.dart
+++ b/bin/main.dart
@@ -14,13 +14,17 @@ void main(List<String> args) {
   var path = args[5];
   final token = args[6];
   final branch = args[7];
+  var repository = args[8];
 
   if (!path.startsWith('/')) {
     path = '/$path';
   }
+  if (repository.isEmpty) {
+    repository = env['GITHUB_REPOSITORY'].toString();
+  }
 
   final remote =
-      'https://${env['GITHUB_ACTOR']}:$token@github.com/${env['GITHUB_REPOSITORY']}.git';
+      'https://${env['GITHUB_ACTOR']}:$token@github.com/$repository.git';
 
   final cloneInto = 'repo-${DateTime.now().millisecondsSinceEpoch}';
 

--- a/workers/index.js
+++ b/workers/index.js
@@ -16,7 +16,7 @@ async function handleRequest(request) {
     let [nameorg, repo, badgeName, branch, ...split_path ] = splitted
     branch = branch || 'shields';
     let path = 'shields.json';
-    if (typeof split_path !== 'undefined') {
+    if (split_path.length > 0) {
         path = split_path.join('/')
     }
 

--- a/workers/index.js
+++ b/workers/index.js
@@ -13,11 +13,12 @@ const error = 'FF0000';
 async function handleRequest(request) {
     let url = new URL(request.url)
     let splitted = url.pathname.substr(1).split('/')
-    let nameorg = splitted[0];
-    let repo = splitted[1];
-    let badgeName = splitted[2];
-    let branch = splitted[3] || 'shields';
-    let path = splitted[4] || 'shields.json';
+    let [nameorg, repo, badgeName, branch, ...split_path ] = splitted
+    branch = branch || 'shields';
+    let path = 'shields.json';
+    if (typeof split_path !== 'undefined') {
+        path = split_path.join('/')
+    }
 
     if (!namePattern.test(badgeName)) {
         return sendResult('BYOB', 'Invalid badge name in request', error);


### PR DESCRIPTION
# Alternate repo for hosting json and fix to inputs.path

* Allows for use of alternative repo to host shields.json. Useful for running an action in a private repo while pushing shields.json to a public repo where it can be properly referenced.
* Attempts to fix `inputs.path` not properly working for nested paths. i.e. `directory/subfile.json`.
* Updates readme with instructions on new options

**Attempts to fix... while I tested non server script work, I obviously have not tested it in your server. So please be mindful to test before publishing it.**